### PR TITLE
Add support for sending arbitrary messages to peers

### DIFF
--- a/include/zg/ZGPeerSession.h
+++ b/include/zg/ZGPeerSession.h
@@ -167,6 +167,9 @@ protected:
    /** Implemented as a no-op, since by default this session doesn't have a gateway */
    virtual void MessageReceivedFromGateway(const MessageRef & msg, void * userData);
 
+   /** Implemented as a no-op so we don't force subclasses to implement this method */
+   virtual void MessageReceivedFromPeer(const ZGPeerID & peerID, const MessageRef & msg);
+
    /** Must be implemented to reset local state of the specified database to its well-known default state.
      * @param whichDatabase The index of the database to reset (e.g. 0 for the first database, 1 for the second, and so on)
      * @param dbChecksum Passed in as the database's current checksum value.  On return, this should be set to the database's new checksum value.
@@ -288,7 +291,7 @@ private:
    zg_private::ConstPZGBeaconDataRef GetNewSeniorBeaconData() const;
 
    // These methods are called from the PZGNetworkIOSession code
-   void MessageReceivedFromPeer(const ZGPeerID & peerID, const MessageRef & msg);
+   void PrivateMessageReceivedFromPeer(const ZGPeerID & peerID, const MessageRef & msg);
    void BeaconDataChanged(const zg_private::ConstPZGBeaconDataRef & beaconData);
    void BackOrderResultReceived(const zg_private::PZGUpdateBackOrderKey & ubok, const zg_private::ConstPZGDatabaseUpdateRef & optUpdateData);
    zg_private::ConstPZGDatabaseUpdateRef GetDatabaseUpdateByID(uint32 whichDatabase, uint64 updateID) const;

--- a/include/zg/ZGPeerSession.h
+++ b/include/zg/ZGPeerSession.h
@@ -168,8 +168,8 @@ protected:
    virtual void MessageReceivedFromGateway(const MessageRef & msg, void * userData);
 
    /** This method will be called when a message is sent to us by a peersession.
-     * A subclass should override this message to catch all the arbitray messages as this function is implemented as no-op
-     * and will print a warning about receiving an unknown message.
+     * A subclass should override this method to catch all the arbitray messages as this function is 
+     * implemented as no-op and will print a warning about receiving an unknown message.
      * @param fromPpeerID The peerID of the sender
      * @param msg The message sent to this session
      */

--- a/include/zg/ZGPeerSession.h
+++ b/include/zg/ZGPeerSession.h
@@ -167,8 +167,13 @@ protected:
    /** Implemented as a no-op, since by default this session doesn't have a gateway */
    virtual void MessageReceivedFromGateway(const MessageRef & msg, void * userData);
 
-   /** Implemented as a no-op so we don't force subclasses to implement this method */
-   virtual void MessageReceivedFromPeer(const ZGPeerID & peerID, const MessageRef & msg);
+   /** This method will be called when a message is sent to us by a peersession.
+     * A subclass should override this message to catch all the arbitray messages as this function is implemented as no-op
+     * and will print a warning about receiving an unknown message.
+     * @param fromPpeerID The peerID of the sender
+     * @param msg The message sent to this session
+     */
+   virtual void MessageReceivedFromPeer(const ZGPeerID & fromPeerID, const MessageRef & msg);
 
    /** Must be implemented to reset local state of the specified database to its well-known default state.
      * @param whichDatabase The index of the database to reset (e.g. 0 for the first database, 1 for the second, and so on)

--- a/src/ZGPeerSession.cpp
+++ b/src/ZGPeerSession.cpp
@@ -77,6 +77,11 @@ void ZGPeerSession :: MessageReceivedFromGateway(const MessageRef &, void *)
    // empty
 }
 
+void ZGPeerSession :: MessageReceivedFromPeer(const ZGPeerID & peerID, const MessageRef & msg)
+{
+
+}
+
 status_t ZGPeerSession :: AttachedToServer()
 {
    if (StorageReflectSession::AttachedToServer() != B_NO_ERROR) return B_ERROR;
@@ -248,7 +253,7 @@ void ZGPeerSession :: LocalSeniorPeerStatusChanged()
    // empty
 }
 
-void ZGPeerSession :: MessageReceivedFromPeer(const ZGPeerID & fromPeerID, const MessageRef & msg)
+void ZGPeerSession :: PrivateMessageReceivedFromPeer(const ZGPeerID & fromPeerID, const MessageRef & msg)
 {
    switch(msg()->what)
    {
@@ -262,7 +267,7 @@ void ZGPeerSession :: MessageReceivedFromPeer(const ZGPeerID & fromPeerID, const
       case PZG_PEER_COMMAND_USER_MESSAGE:
       {
          MessageRef userMsg = msg()->GetMessage(PZG_PEER_NAME_USER_MESSAGE);
-         if (userMsg()) MessageReceivedFromPeer(fromPeerID, userMsg);
+         if (userMsg()) PrivateMessageReceivedFromPeer(fromPeerID, userMsg);
                    else LogTime(MUSCLE_LOG_ERROR, "ZGPeerSession::MessageReceivedFromPeer:  No user message inside wrapper from [%s]\n", fromPeerID.ToString()());
       }
       break;
@@ -279,7 +284,7 @@ void ZGPeerSession :: MessageReceivedFromPeer(const ZGPeerID & fromPeerID, const
       break;
 
       default:
-         LogTime(MUSCLE_LOG_WARNING, "ZGPeerSession::MessageReceivedFromPeer():  Unknown what code " UINT32_FORMAT_SPEC " in Message from [%s]\n", msg()->what, fromPeerID.ToString()());
+         MessageReceivedFromPeer(fromPeerID, msg);
       break;
    }
 }

--- a/src/ZGPeerSession.cpp
+++ b/src/ZGPeerSession.cpp
@@ -77,7 +77,7 @@ void ZGPeerSession :: MessageReceivedFromGateway(const MessageRef &, void *)
    // empty
 }
 
-void ZGPeerSession :: MessageReceivedFromPeer(const ZGPeerID & peerID, const MessageRef & msg)
+void ZGPeerSession :: MessageReceivedFromPeer(const ZGPeerID & fromPeerID, const MessageRef & msg)
 {
    LogTime(MUSCLE_LOG_WARNING, "ZGPeerSession::MessageReceivedFromPeer():  Unknown what code " UINT32_FORMAT_SPEC " in Message from [%s]\n", msg()->what, fromPeerID.ToString()());
 }

--- a/src/ZGPeerSession.cpp
+++ b/src/ZGPeerSession.cpp
@@ -79,7 +79,7 @@ void ZGPeerSession :: MessageReceivedFromGateway(const MessageRef &, void *)
 
 void ZGPeerSession :: MessageReceivedFromPeer(const ZGPeerID & peerID, const MessageRef & msg)
 {
-
+   LogTime(MUSCLE_LOG_WARNING, "ZGPeerSession::MessageReceivedFromPeer():  Unknown what code " UINT32_FORMAT_SPEC " in Message from [%s]\n", msg()->what, fromPeerID.ToString()());
 }
 
 status_t ZGPeerSession :: AttachedToServer()

--- a/src/private/PZGNetworkIOSession.cpp
+++ b/src/private/PZGNetworkIOSession.cpp
@@ -174,7 +174,7 @@ void PZGNetworkIOSession :: MessageReceivedFromInternalThread(const MessageRef &
             if (SendMessageToInternalThread(MessageRef(&_retryMsg, false)) != B_NO_ERROR) LogTime(MUSCLE_LOG_ERROR, "Couldn't send message to invalidate last received beacon data!\n");
          } 
       }
-      else _master->MessageReceivedFromPeer(tag.GetPeerID(), msg);
+      else _master->PrivateMessageReceivedFromPeer(tag.GetPeerID(), msg);
    }
 }
 
@@ -633,7 +633,7 @@ void PZGNetworkIOSession :: ComputerJustWokeUp()
 
 void PZGNetworkIOSession :: UnicastMessageReceivedFromPeer(const ZGPeerID & remotePeerID, const MessageRef & msg)
 {
-   _master->MessageReceivedFromPeer(remotePeerID, msg);
+   _master->PrivateMessageReceivedFromPeer(remotePeerID, msg);
 }
 
 status_t PZGNetworkIOSession :: RequestBackOrderFromSeniorPeer(const PZGUpdateBackOrderKey & ubok)


### PR DESCRIPTION
Added support for sending arbitrary messages to peers by:

- Changing the current MessageReceivedFromPeer to PrivateMessageReceivedFromPeer
- Adding a protected virtual MessageReceivedFromPeer which a subclass can override to catch the messages
- When PrivateMessageReceivedFromPeer can't do anything with the message it will call MessageReceivedFromPeer to pass the message to (a possible) subclass.

Another solution would be to make the subclass responsible for calling it's super MessageReceivedFromPeer to pass through the internal ZG messages.

I choose to do it this way so that there is no chance that internal PZG messages won't get passed through by accidentally not calling the supers MessageReceivedFromPeer. 

Although I think the current way of implementing is the most safe, the second option would be more in line with how the methods MessageReceivedFromGateway and MessageReceivedFromSession are used in MUSCLE and ZG.

If you would like me to change stuff or have any questions or remarks, please let me know.