### PR TITLE
Add target_include_directories ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ file(GLOB ZG_SRCS
 
 add_library(zg ${ZG_SRCS})
 target_link_libraries(zg muscle)
+target_include_directories(zg PUBLIC include)
 
 if (APPLE)
    target_link_libraries(zg "-framework IOKit")


### PR DESCRIPTION
to allow super projects to find zg header files.

This change will add the zg include directory to targets linking with zg like so:

`target_link_libraries(SuperProject PRIVATE zg) `